### PR TITLE
bump maven version, because the ubuntu one is pretty outdated

### DIFF
--- a/builder/java/java_openjdk7/Dockerfile
+++ b/builder/java/java_openjdk7/Dockerfile
@@ -5,5 +5,9 @@ USER ubuntu
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 RUN sudo apt-get -y install openjdk-7-jdk default-jdk        && \
-    sudo apt-get -y install ant ant-contrib ivy maven gradle && \
+    sudo apt-get -y install ant ant-contrib ivy gradle && \
     sudo update-java-alternatives -s java-1.7.0-openjdk-amd64 2> /dev/null
+
+
+RUN cd /tmp && wget  http://apache.org/dist/maven/maven-3/3.2.1/binaries/apache-maven-3.2.1-bin.tar.gz
+RUN cd /opt && sudo tar xzf /tmp/apache-maven-3.2.1-bin.tar.gz && sudo ln -fs /opt/apache-maven-3.2.1/bin/mvn /usr/bin/mvn


### PR DESCRIPTION
Installing last stable Apache Maven version.
The one installed using apt-get install is quite old and suffer some HTTPS bugs.
Example of broken build:
 https://drone.io/github.com/jvermillard/leshan/34
