### PR TITLE
Node latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Node Images
 
 ```sh
 sudo docker build -rm -t bradrydzewski/node builder/node/node/
+sudo docker build -rm -t bradrydzewski/node:0.11 builder/node/node_0.11/
 sudo docker build -rm -t bradrydzewski/node:0.10 builder/node/node_0.10/
 sudo docker build -rm -t bradrydzewski/node:0.8  builder/node/node_0.8/
 sudo docker build -rm -t bradrydzewski/node:0.6  builder/node/node_0.6/

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ sudo docker build -rm -t bradrydzewski/node builder/node/node/
 sudo docker build -rm -t bradrydzewski/node:0.11 builder/node/node_0.11/
 sudo docker build -rm -t bradrydzewski/node:0.10 builder/node/node_0.10/
 sudo docker build -rm -t bradrydzewski/node:0.8  builder/node/node_0.8/
-sudo docker build -rm -t bradrydzewski/node:0.6  builder/node/node_0.6/
 ```
 
 PHP Images

--- a/builder/base/rootfs/etc/drone.d/nodejs.sh
+++ b/builder/base/rootfs/etc/drone.d/nodejs.sh
@@ -1,2 +1,2 @@
 . /home/ubuntu/nvm/nvm.sh
-nvm use v0.10.22 > /dev/null
+nvm use 0.10 > /dev/null

--- a/builder/base/scripts/nodejs.sh
+++ b/builder/base/scripts/nodejs.sh
@@ -10,4 +10,4 @@
 
 git clone git://github.com/creationix/nvm.git /home/ubuntu/nvm
 . /home/ubuntu/nvm/nvm.sh
-nvm install v0.10.22
+nvm install 0.10

--- a/builder/node/node_0.10/Dockerfile
+++ b/builder/node/node_0.10/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /home/ubuntu
 USER ubuntu
 ADD nodejs.sh /etc/drone.d/
 
-# we currently install node 10.22 in the base image
+# we currently install node 0.10 in the base image
 # so we'll comment this out for now
-#RUN /bin/bash -c ". /home/ubuntu/nvm/nvm.sh && nvm install v0.10.22"
+#RUN /bin/bash -c ". /home/ubuntu/nvm/nvm.sh && nvm install 0.10"

--- a/builder/node/node_0.10/nodejs.sh
+++ b/builder/node/node_0.10/nodejs.sh
@@ -1,2 +1,2 @@
 . /home/ubuntu/nvm/nvm.sh
-nvm use v0.10.22
+nvm use 0.10

--- a/builder/node/node_0.11/Dockerfile
+++ b/builder/node/node_0.11/Dockerfile
@@ -1,0 +1,7 @@
+FROM bradrydzewski/base
+
+WORKDIR /home/ubuntu
+USER ubuntu
+ADD nodejs.sh /etc/drone.d/
+
+RUN /bin/bash -c ". /home/ubuntu/nvm/nvm.sh && nvm install 0.11"

--- a/builder/node/node_0.11/nodejs.sh
+++ b/builder/node/node_0.11/nodejs.sh
@@ -1,0 +1,2 @@
+. /home/ubuntu/nvm/nvm.sh
+nvm use 0.11

--- a/builder/node/node_0.8/Dockerfile
+++ b/builder/node/node_0.8/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /home/ubuntu
 USER ubuntu
 ADD nodejs.sh /etc/drone.d/
 
-RUN /bin/bash -c ". /home/ubuntu/nvm/nvm.sh && nvm install v0.8.26"
+RUN /bin/bash -c ". /home/ubuntu/nvm/nvm.sh && nvm install 0.8"

--- a/builder/node/node_0.8/nodejs.sh
+++ b/builder/node/node_0.8/nodejs.sh
@@ -1,2 +1,2 @@
 . /home/ubuntu/nvm/nvm.sh
-nvm use v0.8.26
+nvm use 0.8

--- a/builder/setup
+++ b/builder/setup
@@ -49,6 +49,7 @@ build("java:oraclejdk8", "java/java_oraclejdk8/");
 skip("java:android",    "java/android/");
 
 # node
+build("node:0.11", "node/node_0.11/");
 build("node:0.10", "node/node_0.10/");
 build("node:0.8",  "node/node_0.8/");
 


### PR DESCRIPTION
Instead of installing explicit versions of node we could just always install the latest bugfix version of a given minor version.

This pull request would make  #16 obsolete.

I added node 0.11 as people might want to test their node projects for compatibility with upcoming versions as well.