### PR TITLE
Scipy 2.7 Image

### DIFF
--- a/builder/python/scipy_2.7/Dockerfile
+++ b/builder/python/scipy_2.7/Dockerfile
@@ -1,0 +1,6 @@
+FROM bradrydzewski/python:2.7
+
+RUN sudo apt-get update -qq
+RUN sudo apt-get install -qq build-essential libyaml-dev libfftw3-dev libavcodec-dev libavformat-dev python-dev libsamplerate0-dev libtag1-dev
+RUN sudo apt-get install -qq python-numpy python-numpy-dev python-scipy python-pandas libsndfile1 libsndfile1-dev python-nose python-matplotlib python-sklearn python-skimage ipython python-sympy
+RUN sudo apt-get install -qq sox python-pyaudio

--- a/builder/setup
+++ b/builder/setup
@@ -63,6 +63,7 @@ build("python:2.7",  "python/python_2.7/");
 build("python:3.2",  "python/python_3.2/");
 build("python:3.3",  "python/python_3.3/");
 build("python:pypy", "python/pypy/");
+build("scipy:2.7",   "python/scipy_2.7/");
 
 # ruby
 build("ruby:1.9.3", "ruby/ruby_1.9.3/");


### PR DESCRIPTION
Since scientific computing in Python requires quite a few additional libraries (Numpy, Scipy, Scikits etc) it makes sense to create a special image for such users.

 This PR is only to kick off things, if other fields of science need some more general purpose utils or modules, they might be added here too.