### PR TITLE
Adds android support.

### DIFF
--- a/builder/android/android_r22.6.2/Dockerfile
+++ b/builder/android/android_r22.6.2/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /home/ubuntu
 USER ubuntu
 ADD android.sh /etc/drone.d/
 
-RUN sudo apt-get -y install lib32stdc++6 lib32z1 && \
+RUN sudo apt-get update && \
+    sudo apt-get -y install lib32stdc++6 lib32z1 && \
     wget http://dl.google.com/android/android-sdk_r22.6.2-linux.tgz && \
     sudo tar -C /usr/local -xzf android-sdk_r22.6.2-linux.tgz && \
     sudo chown -R ubuntu:ubuntu /usr/local/android-sdk-linux && \

--- a/builder/android/android_r22.6.2/Dockerfile
+++ b/builder/android/android_r22.6.2/Dockerfile
@@ -1,0 +1,12 @@
+FROM bradrydzewski/java:oraclejdk7
+
+WORKDIR /home/ubuntu
+USER ubuntu
+ADD android.sh /etc/drone.d/
+
+RUN sudo apt-get -y install lib32stdc++6 lib32z1 && \
+    wget http://dl.google.com/android/android-sdk_r22.6.2-linux.tgz && \
+    sudo tar -C /usr/local -xzf android-sdk_r22.6.2-linux.tgz && \
+    sudo chown -R ubuntu:ubuntu /usr/local/android-sdk-linux && \
+    rm android-sdk_r22.6.2-linux.tgz && \
+    echo y | /usr/local/android-sdk-linux/tools/android update sdk --filter platform,tool,platform-tool,extra,build-tools-19.1.0 --no-ui --force -a

--- a/builder/android/android_r22.6.2/Dockerfile
+++ b/builder/android/android_r22.6.2/Dockerfile
@@ -9,4 +9,4 @@ RUN sudo apt-get -y install lib32stdc++6 lib32z1 && \
     sudo tar -C /usr/local -xzf android-sdk_r22.6.2-linux.tgz && \
     sudo chown -R ubuntu:ubuntu /usr/local/android-sdk-linux && \
     rm android-sdk_r22.6.2-linux.tgz && \
-    echo y | /usr/local/android-sdk-linux/tools/android update sdk --filter platform,tool,platform-tool,extra,build-tools-19.1.0 --no-ui --force -a
+    (while :; do echo 'y'; sleep 2; done) | /usr/local/android-sdk-linux/tools/android update sdk --filter platform,tool,platform-tool,extra,build-tools-19.1.0 --no-ui --force -a

--- a/builder/android/android_r22.6.2/android.sh
+++ b/builder/android/android_r22.6.2/android.sh
@@ -1,0 +1,3 @@
+# add android tools to path
+export ANDROID_HOME="/usr/local/android-sdk-linux"
+export PATH="$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools"

--- a/builder/android/android_r23/Dockerfile
+++ b/builder/android/android_r23/Dockerfile
@@ -1,0 +1,12 @@
+FROM bradrydzewski/java:oraclejdk7
+
+WORKDIR /home/ubuntu
+USER ubuntu
+ADD android.sh /etc/drone.d/
+
+RUN sudo apt-get -y install lib32stdc++6 lib32z1 && \
+    wget http://dl.google.com/android/android-sdk_r23-linux.tgz && \
+    sudo tar -C /usr/local -xzf android-sdk_r23-linux.tgz && \
+    sudo chown -R ubuntu:ubuntu /usr/local/android-sdk-linux && \
+    rm android-sdk_r23-linux.tgz && \
+    echo y | /usr/local/android-sdk-linux/tools/android update sdk --filter platform,tool,platform-tool,extra,build-tools-19.1.0 --no-ui --force -a

--- a/builder/android/android_r23/Dockerfile
+++ b/builder/android/android_r23/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /home/ubuntu
 USER ubuntu
 ADD android.sh /etc/drone.d/
 
-RUN sudo apt-get -y install lib32stdc++6 lib32z1 && \
+RUN sudo apt-get update && \
+    sudo apt-get -y install lib32stdc++6 lib32z1 && \
     wget http://dl.google.com/android/android-sdk_r23-linux.tgz && \
     sudo tar -C /usr/local -xzf android-sdk_r23-linux.tgz && \
     sudo chown -R ubuntu:ubuntu /usr/local/android-sdk-linux && \

--- a/builder/android/android_r23/Dockerfile
+++ b/builder/android/android_r23/Dockerfile
@@ -9,4 +9,4 @@ RUN sudo apt-get -y install lib32stdc++6 lib32z1 && \
     sudo tar -C /usr/local -xzf android-sdk_r23-linux.tgz && \
     sudo chown -R ubuntu:ubuntu /usr/local/android-sdk-linux && \
     rm android-sdk_r23-linux.tgz && \
-    echo y | /usr/local/android-sdk-linux/tools/android update sdk --filter platform,tool,platform-tool,extra,build-tools-19.1.0 --no-ui --force -a
+    (while :; do echo 'y'; sleep 2; done) | /usr/local/android-sdk-linux/tools/android update sdk --filter platform,tool,platform-tool,extra,build-tools-19.1.0 --no-ui --force -a

--- a/builder/android/android_r23/android.sh
+++ b/builder/android/android_r23/android.sh
@@ -1,0 +1,3 @@
+# add android tools to path
+export ANDROID_HOME="/usr/local/android-sdk-linux"
+export PATH="$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools"

--- a/builder/cleanup
+++ b/builder/cleanup
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# android
+remove("android:r22.6.2")
+remove("android:r23")
+
 # clojure
 remove("lein");
 

--- a/builder/setup
+++ b/builder/setup
@@ -3,6 +3,10 @@
 # base
 skip("base", "base/");
 
+# android
+build("android:r22.6.2", "android/android_r22.6.2")
+build("android:r23", "android/android_r23")
+
 # clojure
 build("lein", "clojure/lein/");
 


### PR DESCRIPTION
This adds docker images for Android, versioned based on the build tools.

I'm not quite sure of the best way to version this.  It would be really nice to have a single Android image, but you need to ensure you have the latest API levels installed.  These images install all platform API levels, along with tools and extras, so that you can build with any API level using the latest build tools.

The problem is, once this image is built on the server, what happens when a new API level comes out?  Is there a way to have the last line (`android update sdk ...`) run each time a new container is made for a build?  Perhaps by putting it in android.sh.  The problem is that that could potentially make for some really slow builds. 

Either way, I think this is a good first step and I'm using it to build my Android apps.  I'd love some feedback.