### PR TITLE
Add mongodb 2.6.7 image

### DIFF
--- a/database/mongodb/mongodb_2.6.7/Dockerfile
+++ b/database/mongodb/mongodb_2.6.7/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:precise
+RUN apt-get -qq update && apt-get -y install wget                       && \
+    wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.7.tgz && \
+    tar xzf mongodb-linux-x86_64-2.6.7.tgz                              && \
+    install -t /usr/bin mongodb-linux-x86_64-2.6.7/bin/*                && \
+    mkdir -p /data/db /var/lib/mongodb/                                 && \
+    rm mongodb-linux-x86_64-2.6.7.tgz                                   && \
+    rm -rf mongodb-linux-x86_64-2.6.7
+EXPOSE 27017
+ENTRYPOINT ["usr/bin/mongod"]
+CMD ["--noprealloc", "--smallfiles"]


### PR DESCRIPTION
The current latest MongoDB image is 2.4, it'd be great to update.